### PR TITLE
Update method to retrieve FieldInfos in TraitsClassBase.cs

### DIFF
--- a/Assets/Plugins/Stats/Runtime/ScriptableObjects/TraitsClassBase.cs
+++ b/Assets/Plugins/Stats/Runtime/ScriptableObjects/TraitsClassBase.cs
@@ -105,14 +105,20 @@ namespace Stats
 
         private static IEnumerable<FieldInfo> GetFieldsByType(Type type)
         {
-            const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            if (Fields.TryGetValue(type, out var byType))
+            if (type == null)
             {
-                return byType;
+                return Array.Empty<FieldInfo>();
             }
 
-            Fields.Add(type, type.GetFields(bindingFlags));
-            return Fields[type];
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly;
+            var fields = new List<FieldInfo>(type.GetFields(flags));
+
+            if (type.BaseType != null)
+            {
+                fields.AddRange(GetFieldsByType(type.BaseType));
+            }
+
+            return fields;
         }
     }
 }


### PR DESCRIPTION
Adjusted the GetFieldsByType method within the TraitsClassBase script to now return all fields from base class as well, previously it only returned the fields from the given type. Also, added a null check to return an empty array if provided type is null.